### PR TITLE
Resolve compilation error on clang 15+

### DIFF
--- a/src/fdwatcher.c
+++ b/src/fdwatcher.c
@@ -26,7 +26,7 @@
  * Return event interface type as a string.
  */
 const char *
-fdwatcher_ev_interface()
+fdwatcher_ev_interface(void)
 {
 #if USE_KQUEUE
 	return "kqueue";
@@ -39,7 +39,7 @@ fdwatcher_ev_interface()
  * Create an FdWatcher object.
  */
 FdWatcher *
-fdwatcher_create()
+fdwatcher_create(void)
 {
 	FdWatcher *fdw = malloc(sizeof (FdWatcher));
 

--- a/src/fdwatcher.h
+++ b/src/fdwatcher.h
@@ -82,7 +82,7 @@ typedef struct fdwatcher {
  * Return the event interface that is being used.  This will return a string
  * like: "epoll" or "kqueue" depending on how it was compiled.
  */
-const char *fdwatcher_ev_interface();
+const char *fdwatcher_ev_interface(void);
 
 /*
  * Create an FdWatcher object.  This object will be passed to the rest of the
@@ -91,7 +91,7 @@ const char *fdwatcher_ev_interface();
  *
  * Returns NULL and sets errno on error.
  */
-FdWatcher *fdwatcher_create();
+FdWatcher *fdwatcher_create(void);
 
 /*
  * Add a file descriptor with the given user data (called `ptr`) to the watch

--- a/src/sshp.c
+++ b/src/sshp.c
@@ -546,7 +546,7 @@ prog_mode_to_string(enum ProgMode mode)
  * Print status - called via SIGUSR1 handler.
  */
 static void
-print_status()
+print_status(void)
 {
 	int num_hosts = 0;
 	int cp_ready = 0;
@@ -590,7 +590,7 @@ print_status()
  * Kill all running child processes.
  */
 static void
-kill_running_processes()
+kill_running_processes(void)
 {
 	for (Host *h = hosts; h != NULL; h = h->next) {
 		assert(h->cp != NULL);
@@ -647,7 +647,7 @@ signal_handler(int signum)
  * outstanding when exit is called.
  */
 static void
-atexit_handler()
+atexit_handler(void)
 {
 	kill_running_processes();
 }
@@ -677,7 +677,7 @@ safe_malloc(size_t size, const char *msg)
  * Create a ChildProcess object.
  */
 static ChildProcess *
-child_process_create()
+child_process_create(void)
 {
 	ChildProcess *cp = safe_malloc(sizeof (ChildProcess),
 	    "child_process_create");
@@ -926,7 +926,7 @@ ends_in_newline(const char *s)
  * Get the current monotonic time in ms.
  */
 static long
-monotonic_time_ms()
+monotonic_time_ms(void)
 {
 	struct timespec t;
 


### PR DESCRIPTION
Fixes the following compile-time error as `-pedantic` and `-Werror` is enabled:

```
error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
```

See https://reviews.llvm.org/D122895 for more details on the change.